### PR TITLE
Set Ubuntu to use UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM phusion/baseimage:0.9.15
 
+# Ensure UTF-8
+RUN locale-gen en_US.UTF-8
+ENV LANG       en_US.UTF-8
+ENV LC_ALL     en_US.UTF-8
+
 ENV HOME /root
 
 RUN /etc/my_init.d/00_regen_ssh_host_keys.sh


### PR DESCRIPTION
This should fix #15 I had a similar issue and the best fix I found was to set UTF-8 as the default language 

Fixes #15