### PR TITLE
Added noninteractive for apt-get installs (take 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,17 +13,17 @@ CMD ["/sbin/my_init"]
 
 # Nginx-PHP Installation
 RUN apt-get update
-RUN apt-get install -y vim curl wget build-essential python-software-properties
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y vim curl wget build-essential python-software-properties
 RUN add-apt-repository -y ppa:ondrej/php5
 RUN add-apt-repository -y ppa:nginx/stable
 RUN apt-get update
-RUN apt-get install -y --force-yes php5-cli php5-fpm php5-mysql php5-pgsql php5-sqlite php5-curl\
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y --force-yes php5-cli php5-fpm php5-mysql php5-pgsql php5-sqlite php5-curl\
 		       php5-gd php5-mcrypt php5-intl php5-imap php5-tidy
 
 RUN sed -i "s/;date.timezone =.*/date.timezone = UTC/" /etc/php5/fpm/php.ini
 RUN sed -i "s/;date.timezone =.*/date.timezone = UTC/" /etc/php5/cli/php.ini
 
-RUN apt-get install -y nginx
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y nginx
 
 RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 RUN sed -i -e "s/;daemonize\s*=\s*yes/daemonize = no/g" /etc/php5/fpm/php-fpm.conf


### PR DESCRIPTION
This prevents a lot of the error messages during install that begin with "debconf: unable to initialize frontend: Dialog". 
![screen shot 2015-05-10 at 1 30 43 pm](https://cloud.githubusercontent.com/assets/3138467/7555576/792fe968-f71d-11e4-8b92-fe5380cca12c.png)
This likely doesn't make any functional difference but it would make it easier to spot actual problems during a docker build.
